### PR TITLE
fix: use changesets/action v2 input names in Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,10 @@ jobs:
       - name: Create release PR or publish
         uses: changesets/action@v2
         with:
-          version: pnpm run version:ci
-          publish: pnpm run release
-          commit: "chore: version packages"
-          title: "chore: version packages"
+          version-script: pnpm run version:ci
+          publish-script: pnpm run release
+          commit-message: "chore: version packages"
+          pr-title: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ env.NPM_TOKEN }}


### PR DESCRIPTION
Release has been red since `changesets/action` was bumped to v2 (PRs #36 / #41). Latest fail: https://github.com/cobusgreyling/outerloop/actions/runs/32946067159

GitHub annotations: v2 renamed `publish` → `publish-script`, `version` → `version-script`, `commit` → `commit-message`, `title` → `pr-title`.

This only renames those four `with:` keys. Command values are unchanged. Confirmed against current [changesets/action README](https://github.com/changesets/action).